### PR TITLE
Specify the availability zone for the public subnet

### DIFF
--- a/terraform/subnets.tf
+++ b/terraform/subnets.tf
@@ -1,4 +1,5 @@
 resource "aws_subnet" "public" {
+  availability_zone = "${var.availability_zone}"
   cidr_block = "10.0.1.0/24"
   vpc_id = "${aws_vpc.kubernetes.id}"
 


### PR DESCRIPTION
Since we're going to try to start EC2 nodes in the user specified availability zone using the public subnet, we need to make sure the public subnet is in the same availability zone or we can end up with errors like the following when trying to apply the resulting terraform manifest.

    * aws_instance.etcd_01: Error launching source instance: InvalidParameterValue: Value (us-east-1e) for parameter availabilityZone is invalid. Subnet 'subnet-a076ed9d' is in the availability zone us-east-1d
        status code: 400, request id: 87450b36-68d0-4a6d-a281-2c46b32557bb